### PR TITLE
Fixes bug on multichar

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -298,11 +298,22 @@ Citizen.CreateThread(function()
         Wait(0)
     end
 
+    if Config.framework == 'esx' then
+        
+        AddEventHandler('esx:onPlayerSpawn', function()
+            TriggerServerCallback('zerodream_parking:getPlayerData', function(data)
+                _g.identifier = data.identifier
+            end)
+        end)
+    else
     -- Load player data
     DebugPrint('Loading player data...')
     TriggerServerCallback('zerodream_parking:getPlayerData', function(data)
         _g.identifier = data.identifier
     end)
+    end
+
+
 
     -- Wait for data load
     while not _g.identifier do

--- a/client/main.lua
+++ b/client/main.lua
@@ -299,7 +299,8 @@ Citizen.CreateThread(function()
     end
 
     if Config.framework == 'esx' then
-        
+        DebugPrint('Loading player data...')
+
         AddEventHandler('esx:onPlayerSpawn', function()
             TriggerServerCallback('zerodream_parking:getPlayerData', function(data)
                 _g.identifier = data.identifier


### PR DESCRIPTION
Following Error is fixed via this Pull Request:




> The ESX code is broken when using Multichar.
> On line 301 till 305
> 
> ```
>    -- Load player data
>     DebugPrint('Loading player data...')
>     TriggerServerCallback('zerodream_parking:getPlayerData', function(data)
>         _g.identifier = data.identifier
>     end)
> ```
> 
> This Script trys instantly to fetch the Player data on join. But on Multichar Server it won’t work. Becouse on the join the Player don’t have the right identifier. I think if u implement esx:onPlayerSpawn here it should work. I am currently testing it and I can do a pull reqeust if its working on my end if you want
> 
> **ERROR:**
> 
> `[script:zerodream_par] SCRIPT ERROR: @zerodream_parking/server/main.lua:68: attempt to index a nil value (local 'xPlayer')
> `
> **More Information:**
> 
> I’m not quite sure if its happend becouse of that error. But when a Player Joins no Cars are Spawned. They are Only Spawned for the client if I restart the Script while the Player is on the Server.(No error if I do that becouse the Script can get the right identifier)
> 

See: https://forum.cfx.re/t/standalone-esx-zerodream-parking-parking-your-car-like-in-real-life/4986567/29?u=noobspielt